### PR TITLE
Joining the responder threads from the consumer work pool doesn't work

### DIFF
--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -12,14 +12,13 @@ module Salemove
       def spawn(service)
         @process_monitor.start
 
-        threads = (1..@threads_count).map {
+        responders = (1..@threads_count).map {
           ServiceSpawner.spawn(@process_monitor, service, @messenger)
         }
 
         sleep 1 while @process_monitor.running?
 
-        threads.each(&:cancel)
-        threads.each(&:join)
+        responders.each(&:cancel)
       end
 
       class ServiceSpawner


### PR DESCRIPTION
when there are other responders in addition to the service responders. It seems to me that it is not necessary to join all the existing consumer threads, cancelling the service responders and terminating the process seems sufficient.
