### PR TITLE
Handle services with tapped queues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    process_handler (0.1.0)
+    process_handler (0.1.2)
       airbrake
       sucker_punch (~> 1.1)
 

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
This allows creating pivot services which just tap into messages.

I added another constant `TAPPED_QUEUES` which will be checked for on the service.

I moved (both lib and spec) code around a bit to reuse existing functionality. 