### PR TITLE
Make a logger less noisy

### DIFF
--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -170,10 +170,14 @@ module Salemove
           handle_exception(exception, input)
         end
 
+        PROCESSED_REQUEST_LOG_KEYS = [:error, :success]
+
         def delegate_to_service(input)
           request_id = input[:request_id]
           result = PivotProcess.benchmark(input) { @service.call(input) }
-          PivotProcess.logger.info "Processed request", result.merge(request_id: request_id)
+          PivotProcess.logger.info(
+            "Processed request", result.select{|k, _| PROCESSED_REQUEST_LOG_KEYS.include?(k)}.merge(request_id: request_id)
+          )
           result
         end
 


### PR DESCRIPTION
The logger was very noisy and put a lot of output in the logs, most of
which was useless for info level. In addition, we already have a debug
level logger when the message is actually produced to rabbitmq. It was
basically double log when logging at the info level.