### PR TITLE
Hide env secrets from Airbrake Kube events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'rufus-scheduler'
+gem 'rufus-scheduler', '~> 3.2.1'
 gem 'logasm'
 
 group :test do

--- a/lib/salemove/process_handler/notifier_factory.rb
+++ b/lib/salemove/process_handler/notifier_factory.rb
@@ -14,6 +14,11 @@ module Salemove
             airbrake.secure = true
             airbrake.host = conf.fetch(:host)
             airbrake.api_key = conf.fetch(:api_key)
+            [/_HOST$/, /_TCP$/, /_UDP$/, /_PROTO$/, /_ADDR$/, 'PWD',
+            'GEM_HOME', 'PATH', 'SERVICE_NAME', 'RUBY_MAJOR', 'RUBY_VERSION', 
+            'RUN_ENV', 'HOME', 'RUBYGEMS_VERSION', 'BUNDLER_VERSION'].each { 
+              | param_whitelist_filter| airbrake.params_whitelist_filters << param_whitelist_filter 
+            }
           end
           Airbrake
         elsif conf && conf[:type] == 'growl'

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '0.2.9'
+    VERSION = '0.3.0'
   end
 end

--- a/spec/process_handler/airbrake_spec.rb
+++ b/spec/process_handler/airbrake_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+require 'airbrake'
+require 'airbrake/notice'
+require 'salemove/process_handler/notifier_factory'
+
+describe 'Airbrake configuration' do
+
+  let (:notice) { Airbrake::Notice.new(notice_args.merge(custom_notice_args)) }
+  let (:notifier_factory_conf) { {:type => 'airbrake',:host => 'localhost',:api_key => 'abc123'} }
+  let (:airbrake) { ProcessHandler::NotifierFactory.get_notifier('env', 'Process name', notifier_factory_conf) }
+  # Notice needs Airbrake configuration merged with :exception for creating the exception notification
+  let (:notice_args) { {:exception => Exception.new}.merge(airbrake.configuration) }
+  let (:filtered) { '[FILTERED]' }
+
+  # Uses Airbrake configuration's 'params_whitelist_filters' param for filtering
+  context 'whitelist filter' do
+
+    let (:custom_notice_args) {
+      {
+        :params_filters => [], # Remove blacklist to test whitelist
+        :parameters => {
+          'API_PORT_80_TCP_PROTO' => 'tcp',
+          'HOME' => '/home/sm',
+          'SECRET_PASS' => 'Parool123',
+          'SOME_PROTO_KEY' => 'value',
+          'PROTO_KEY' => 'abc123'
+        },
+        :cgi_data => {
+          'HTTP_HOST' => 'localhost:3001',
+          'RANDOM' => 'value',
+          'HOME' => 'sweet home'
+        }
+      }
+    }
+
+    it 'allows parameters by regex' do
+      expect(notice[:parameters]['API_PORT_80_TCP_PROTO']).to eq 'tcp'
+      expect(notice[:cgi_data]['HTTP_HOST']).to eq 'localhost:3001'
+    end
+
+    it 'allows parameters by string' do
+      expect(notice[:parameters]['HOME']).to eq '/home/sm'
+      expect(notice[:cgi_data]['HOME']).to eq 'sweet home'
+    end
+
+    it 'filters variables not in whitelist' do
+      expect(notice[:parameters]['SECRET_PASS']).to eq filtered
+      expect(notice[:parameters]['SOME_PROTO_KEY']).to eq filtered
+      expect(notice[:parameters]['PROTO_KEY']).to eq filtered
+      expect(notice[:cgi_data]['RANDOM']).to eq filtered
+    end
+
+  end
+
+end


### PR DESCRIPTION
INF-499

Prevents sending secret environment variables to Airbrake by
whitelisting certain variable names and name patterns.

Affects all projects that use the process_handler library
(i.e. all but api and backend-web which have their own
Airbrake configuration files).