### PR TITLE
Move 'env' setting to Airbrake configuration

### DIFF
--- a/lib/salemove/process_handler/cron_process.rb
+++ b/lib/salemove/process_handler/cron_process.rb
@@ -25,12 +25,11 @@ module Salemove
 
       attr_reader :process_monitor
 
-      def initialize(env: 'development',
-                     notifier: nil,
+      def initialize(notifier: nil,
                      notifier_factory: NotifierFactory,
                      scheduler_options: {})
         @schedules = []
-        @exception_notifier = notifier_factory.get_notifier(env, 'Cron Process', notifier)
+        @exception_notifier = notifier_factory.get_notifier('Cron Process', notifier)
         @scheduler = CronScheduler.new @exception_notifier, scheduler_options
         @process_monitor = CronProcessMonitor.new(self)
       end

--- a/lib/salemove/process_handler/notifier_factory.rb
+++ b/lib/salemove/process_handler/notifier_factory.rb
@@ -6,18 +6,18 @@ module Salemove
   module ProcessHandler
     class NotifierFactory
 
-      def self.get_notifier(env, process_name, conf)
+      def self.get_notifier(process_name, conf)
         if conf && conf[:type] == 'airbrake'
           Airbrake.configure do |airbrake|
             airbrake.async = true
-            airbrake.environment_name = env
+            airbrake.environment_name = conf.fetch(:environment_name)
             airbrake.secure = true
             airbrake.host = conf.fetch(:host)
             airbrake.api_key = conf.fetch(:api_key)
             [/_HOST$/, /_TCP$/, /_UDP$/, /_PROTO$/, /_ADDR$/, 'PWD',
-            'GEM_HOME', 'PATH', 'SERVICE_NAME', 'RUBY_MAJOR', 'RUBY_VERSION', 
-            'RUN_ENV', 'HOME', 'RUBYGEMS_VERSION', 'BUNDLER_VERSION'].each { 
-              | param_whitelist_filter| airbrake.params_whitelist_filters << param_whitelist_filter 
+            'GEM_HOME', 'PATH', 'SERVICE_NAME', 'RUBY_MAJOR', 'RUBY_VERSION',
+            'RUN_ENV', 'HOME', 'RUBYGEMS_VERSION', 'BUNDLER_VERSION'].each {
+              | param_whitelist_filter| airbrake.params_whitelist_filters << param_whitelist_filter
             }
           end
           Airbrake

--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -21,7 +21,6 @@ module Salemove
       end
 
       def initialize(messenger,
-                     env: 'development',
                      notifier: nil,
                      notifier_factory: NotifierFactory,
                      process_monitor: ProcessMonitor.new,
@@ -29,7 +28,7 @@ module Salemove
                      exit_enforcer: nil)
         @messenger = messenger
         @process_monitor = process_monitor
-        @exception_notifier = notifier_factory.get_notifier(env, process_name, notifier)
+        @exception_notifier = notifier_factory.get_notifier(process_name, notifier)
         # Needed for forcing exit from jruby with exit(0)
         @exit_enforcer = exit_enforcer || Proc.new {}
       end

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '0.3.0'
+    VERSION = '1.0.0'
   end
 end

--- a/spec/process_handler/airbrake_spec.rb
+++ b/spec/process_handler/airbrake_spec.rb
@@ -6,14 +6,19 @@ require 'salemove/process_handler/notifier_factory'
 describe 'Airbrake configuration' do
 
   let (:notice) { Airbrake::Notice.new(notice_args.merge(custom_notice_args)) }
-  let (:notifier_factory_conf) { {:type => 'airbrake',:host => 'localhost',:api_key => 'abc123'} }
-  let (:airbrake) { ProcessHandler::NotifierFactory.get_notifier('env', 'Process name', notifier_factory_conf) }
+  let (:environment_name) { 'SOME_ENVIRONMENT' }
+  let (:notifier_factory_conf) { {:type => 'airbrake',
+                                  :host => 'localhost',
+                                  :api_key => 'abc123',
+                                  :environment_name => environment_name} }
+  let (:airbrake) { ProcessHandler::NotifierFactory.get_notifier('Process name', notifier_factory_conf) }
   # Notice needs Airbrake configuration merged with :exception for creating the exception notification
   let (:notice_args) { {:exception => Exception.new}.merge(airbrake.configuration) }
+  let (:custom_notice_args) { {} }
   let (:filtered) { '[FILTERED]' }
 
   # Uses Airbrake configuration's 'params_whitelist_filters' param for filtering
-  context 'whitelist filter' do
+  describe 'whitelist filtering' do
 
     let (:custom_notice_args) {
       {
@@ -52,4 +57,7 @@ describe 'Airbrake configuration' do
 
   end
 
+  it 'configures environment_name' do
+    expect(notice[:environment_name]).to eq environment_name
+  end
 end

--- a/spec/process_handler/cron_process_spec.rb
+++ b/spec/process_handler/cron_process_spec.rb
@@ -61,7 +61,7 @@ describe ProcessHandler::CronProcess do
 
   describe 'exception handler' do
     let(:process) { ProcessHandler::CronProcess.new(params) }
-    let(:params) {{ env: 'test', notifier_factory: notifier_factory,
+    let(:params) {{ notifier_factory: notifier_factory,
       scheduler_options: {frequency: 0.2} }}
     let(:notifier_factory) { double('NotifierFactory') }
     let(:exception_notifier) { double('Airbrake') }

--- a/spec/process_handler/pivot_process_spec.rb
+++ b/spec/process_handler/pivot_process_spec.rb
@@ -8,7 +8,7 @@ describe ProcessHandler::PivotProcess do
   let(:handler)   { double('Handler') }
   let(:thread)    { double('Thread') }
   let(:process) { ProcessHandler::PivotProcess.new(messenger, process_params) }
-  let(:process_params) {{ process_monitor: monitor , notifier_factory: notifier_factory, env: 'test' }}
+  let(:process_params) {{ process_monitor: monitor , notifier_factory: notifier_factory}}
   let(:notifier_factory) { double('NotifierFactory') }
   let(:responder) { double(shutdown: true) }
   let(:logger) { Logasm.build('test-app', []) }


### PR DESCRIPTION
Previously, Process classes had `env` as an `initialize` named
parameter. The `env` var however was only used in the creation of
optional Airbrake `notifier` initialization. Requiring specification
of `env` regardless of whether Airbrake was used, incorrectly
positioned/scoped the setting. It also needlessley segregated the
Airbrake setting from the remaining notifier settings.