### PR TITLE
Ensure Freddy.trace.context responds to #to_h before using it

### DIFF
--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -20,9 +20,15 @@ module Salemove
         @logger = logger
       end
 
+      def self.tracing_supported?
+        defined?(Freddy) &&
+          Freddy.respond_to?(:trace) &&
+          Freddy.trace.context.respond_to?(:to_h)
+      end
+
       def self.trace_information
-        if defined?(Freddy) && Freddy.respond_to?(:trace)
-          {trace: Freddy.trace.to_h}
+        if tracing_supported?
+          {trace: Freddy.trace.context.to_h}
         else
           {}
         end

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end


### PR DESCRIPTION
Freddy can use other tracers than logasm-tracer which might not have
to_h method. It will later be removed from the logasm-tracer as well
most likely.