### PR TITLE
Raise "Received request" log to info level

### DIFF
--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -172,7 +172,7 @@ module Salemove
         end
 
         def handle_request(input)
-          PivotProcess.logger.debug "Received request", PivotProcess.trace_information.merge(input)
+          PivotProcess.logger.info "Received request", PivotProcess.trace_information.merge(input)
           if input.has_key?(:ping)
             { success: true, pong: 'pong' }
           else

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end


### PR DESCRIPTION
It was previously assumed that the tracing will take care of it. However it is
useful as a general log information as well. The TapInto handler already has it
as info level.