### PR TITLE
Add statsd support to PivotProcess

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,14 @@ Example of using pivot process:
 ```ruby
   service = MyService.new
   freddy = Freddy.new
+  statsd = Statsd.new
+  logger = Logasm.build('my-app', {stdout: {level: :debug}})
 
-  process = Salemove::ProcessHandler::PivotProcess.new(freddy)
+  process = Salemove::ProcessHandler::PivotProcess.new(
+    freddy: freddy,
+    logger: logger,
+    statsd: statsd
+  )
   process.spawn(service)
 ```
 

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '1.1.2'
+    VERSION = '2.0.0'
   end
 end

--- a/spec/fixtures/composite_service.rb
+++ b/spec/fixtures/composite_service.rb
@@ -13,9 +13,14 @@ module Salemove
     end
   end
 
-  class Messenger
+  class Freddy
     def respond_to(*)
       ResponderHandler.new
+    end
+  end
+
+  class DummyStatsd
+    def histogram(*)
     end
   end
 
@@ -28,8 +33,11 @@ module Salemove
   cron_process.schedule('0.5')
   cron_process.schedule('5', some: 'params')
 
-  ProcessHandler::PivotProcess.logger = Logger.new('/dev/null')
-  pivot_process = ProcessHandler::PivotProcess.new(Messenger.new)
+  pivot_process = ProcessHandler::PivotProcess.new(
+    freddy: Freddy.new,
+    logger: Logger.new('/dev/null'),
+    statsd: DummyStatsd.new
+  )
 
   ProcessHandler.start_composite do
     add cron_process, EchoResultService.new


### PR DESCRIPTION
Instead of parsing all this using fluentd it is more effecient to send it
to statsd directly.

Also changes PivotProcess initialization signature to take all dependencies
as arguments instead of using globals.