### PR TITLE
Log all input keys when request is processed

### DIFF
--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -191,7 +191,8 @@ module Salemove
 
         def delegate_to_service(input)
           result = @benchmarker.call(input) { @service.call(input) }
-          if !result.respond_to?(:fulfilled?)
+
+          unless result.respond_to?(:fulfilled?)
             log_processed_request(input, result)
           end
 
@@ -200,13 +201,14 @@ module Salemove
 
         def log_processed_request(input, result)
           attributes = result
-            .select {|k, _| PROCESSED_REQUEST_LOG_KEYS.include?(k)}
-            .merge(type: input[:type])
+            .select { |k, _| PROCESSED_REQUEST_LOG_KEYS.include?(k) }
+            .merge(input)
             .merge(PivotProcess.trace_information)
 
           if @log_error_as_string
             attributes[:error] = attributes[:error].to_s if attributes.has_key?(:error)
           end
+
           @logger.info 'Processed request', attributes
         end
 

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '2.1.0'
+    VERSION = '2.2.0'
   end
 end

--- a/spec/process_handler/pivot_process_spec.rb
+++ b/spec/process_handler/pivot_process_spec.rb
@@ -99,33 +99,44 @@ describe ProcessHandler::PivotProcess do
     end
 
     describe 'when service responds with an error object' do
-      let(:result) { { success: false, error: {error: 'hey', message: 'message' } } }
+      let(:result) { { success: false, error: { error: 'hey', message: 'message' } } }
+      let(:input) { { type: :update, value: 42 } }
 
       before do
         expect(service).to receive(:call).with(input) { result }
       end
 
-      it 'logs the message as an object' do
-        expect(logger).to receive(:info).with("Received request", {})
+      it 'logs the message as an object and includes input' do
+        expect(logger).to receive(:info).with('Received request', input)
+
         expect(logger).to receive(:info)
           .with(
-            "Processed request",
-            { success: false, error: {error: 'hey', message: 'message'}, type: nil }
+            'Processed request',
+            {
+              success: false,
+              error: { error: 'hey', message: 'message' }
+            }.merge(input)
           )
-        subject()
+
+        subject
       end
 
       describe 'when log_error_as_string' do
         let(:log_error_as_string) { true }
 
-        it 'logs the message as string' do
-          expect(logger).to receive(:info).with("Received request", {})
+        it 'logs the message as string and includes input' do
+          expect(logger).to receive(:info).with('Received request', input)
+
           expect(logger).to receive(:info)
             .with(
-              "Processed request",
-              { success: false, error: "{:error=>\"hey\", :message=>\"message\"}", type: nil }
+              'Processed request',
+              {
+                success: false,
+                error: '{:error=>"hey", :message=>"message"}'
+              }.merge(input)
             )
-          subject()
+
+          subject
         end
       end
     end

--- a/spec/process_handler/pivot_process_spec.rb
+++ b/spec/process_handler/pivot_process_spec.rb
@@ -142,14 +142,12 @@ describe ProcessHandler::PivotProcess do
     end
 
     shared_examples 'an error_handler' do
-
       it 'logs error' do
-        expect(logger).to receive(:error)
-        subject()
+        expect(logger).to receive(:error).with(an_instance_of(String), input)
+        subject
       end
 
       describe 'with exception_notifier' do
-
         let(:exception_notifier) { double('Airbrake') }
 
         before do
@@ -158,16 +156,15 @@ describe ProcessHandler::PivotProcess do
 
         it 'triggers exception_notifier' do
           expect(exception_notifier).to receive(:notify_or_ignore)
-          subject()
+          subject
         end
       end
-
     end
 
     describe 'when service raises exception' do
-
+      let(:input) { { type: :update, value: 42 } }
       let(:result) { { success: false, error: exception } }
-      let(:exception) { "what an unexpected exception!" }
+      let(:exception) { 'what an unexpected exception!' }
 
       before do
         expect(service).to receive(:call).with(input) { raise exception }
@@ -175,11 +172,10 @@ describe ProcessHandler::PivotProcess do
 
       it 'acks the message properly' do
         expect(handler).to receive(:error).with(result)
-        subject()
+        subject
       end
 
       it_behaves_like 'an error_handler'
-
     end
 
     describe 'when result is fulfillable' do


### PR DESCRIPTION
It currently very hard to link "Request received" and "Processed request"
messages, because the latter doesn't log any input attributes, except `type`.

This change will allow to search both "Request received" and "Processed
request" messages by some input attributes.

Also input attributes are added to logged exception, also for better accessibility.