### PR TITLE
Update Airbrake 4.3 -> 7.4

### DIFF
--- a/lib/salemove/process_handler/cron_process.rb
+++ b/lib/salemove/process_handler/cron_process.rb
@@ -13,9 +13,7 @@ module Salemove
       end
 
       def on_error(job, error)
-        if @exception_notifier
-          @exception_notifier.notify_or_ignore(error, cgi_data: ENV.to_hash)
-        end
+        @exception_notifier.notify_or_ignore(error, {}) if @exception_notifier
         super
       end
 

--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -113,13 +113,7 @@ module Salemove
           message = [exception.inspect, *exception.backtrace].join("\n")
           @logger.error(message, input)
 
-          if @exception_notifier
-            @exception_notifier.notify_or_ignore(
-              exception,
-              cgi_data: ENV.to_hash,
-              parameters: input
-            )
-          end
+          @exception_notifier.notify_or_ignore(exception, input) if @exception_notifier
         end
       end
 
@@ -207,13 +201,7 @@ module Salemove
           message = [exception.inspect, *exception.backtrace].join("\n")
           @logger.error(message, input)
 
-          if @exception_notifier
-            @exception_notifier.notify_or_ignore(
-              exception,
-              cgi_data: ENV.to_hash,
-              parameters: input
-            )
-          end
+          @exception_notifier.notify_or_ignore(exception, input) if @exception_notifier
 
           { success: false, error: exception.message }
         end

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '2.3.0'
+    VERSION = '3.0.0'
   end
 end

--- a/process_handler.gemspec
+++ b/process_handler.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'airbrake', '~> 4.3'
+  spec.add_dependency 'airbrake', '~> 7.4'
+  spec.add_dependency 'timers', '~> 4.1.2'
   spec.add_dependency 'sucker_punch', '~> 1.1' # for async airbrake notifications
   spec.add_dependency 'growl'
   spec.add_dependency 'terminal-notifier'


### PR DESCRIPTION
Update Airbrake 4.3 -> 7.4

It was not possible to update Airbrake while keeping its configuration
backwards-compatible, as the updated version requires the 'project_id'
parameter to be defined. As the changes are not backwards-compatible
anyways, it was decided to also 'modernize' all other parameters
so they would match Airbrake configuration parameter names.

- `project_id` was added (required)
- `api_key` was renamed to `project_key` (required)
- `environment_name` was renamed to `environment` (required)
- `ignore_environments` was added (optional)
  - Airbrake does not filter by `test and `development` environments
    implicitly anymore, so be sure to use this parameter if you
    don't want to send error reports from such environments.
    Accepts strings, symbols and regexes.
- `host` is same as before (required)
- `notifier_name` was added (optional)
  - useful when multiple Airbrake notifiers are used in one project

Airbrake client does not use the `async` flag anymore, so it was dropped
from the factory, too (`Airbrake.notify` already notifies asynchronously).
Same with the `secure` flag - sending the reports is secure by default.