### PR TITLE
Handle keyword argument warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.1']
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run lint & tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.1.0
-before_script:
-  - bundle
-script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProcessHandler
 
-[![Build Status](https://travis-ci.org/salemove/process_handler.svg?branch=master)](https://travis-ci.org/salemove/process_handler)
+[![Build Status](https://github.com/salemove/process_handler/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/salemove/process_handler/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Code Climate](https://codeclimate.com/github/salemove/process_handler/badges/gpa.svg)](https://codeclimate.com/github/salemove/process_handler)
 
 ProcessHandler helps to spawn and manage services. There are multiple types of processes. Every process knows how to handle `SIGINT` and `SIGTERM` signals.

--- a/lib/salemove/process_handler/cron_process.rb
+++ b/lib/salemove/process_handler/cron_process.rb
@@ -42,7 +42,7 @@ module Salemove
       def spawn(service, blocking: true)
         @process_monitor.start
         @schedules.each do |schedule|
-          spawn_schedule(service, schedule)
+          spawn_schedule(service, **schedule)
         end
         @scheduler.join if blocking
       end

--- a/lib/salemove/process_handler/pivot_process.rb
+++ b/lib/salemove/process_handler/pivot_process.rb
@@ -177,7 +177,7 @@ module Salemove
         end
 
         def delegate_to_service(input)
-          result = @benchmarker.call(input) { @service.call(input) }
+          result = @benchmarker.call(input) { @service.call(**input) }
 
           unless result.respond_to?(:fulfilled?)
             log_processed_request(input, result)

--- a/lib/salemove/process_handler/version.rb
+++ b/lib/salemove/process_handler/version.rb
@@ -1,5 +1,5 @@
 module Salemove
   module ProcessHandler
-    VERSION = '4.0.0'
+    VERSION = '4.1.0'
   end
 end

--- a/spec/process_handler/cron_process_spec.rb
+++ b/spec/process_handler/cron_process_spec.rb
@@ -42,7 +42,7 @@ describe ProcessHandler::CronProcess do
   end
 
   describe 'scheduler' do
-    let(:process) { ProcessHandler::CronProcess.new(scheduler_options: {frequency: 0.1}) }
+    let(:process) { ProcessHandler::CronProcess.new(**{scheduler_options: {frequency: 0.1}}) }
     let(:messages) { [] }
     let(:queue) { Queue.new }
 
@@ -60,7 +60,7 @@ describe ProcessHandler::CronProcess do
   end
 
   describe 'exception handler' do
-    let(:process) { ProcessHandler::CronProcess.new(params) }
+    let(:process) { ProcessHandler::CronProcess.new(**params) }
     let(:params) {{ notifier_factory: notifier_factory,
       scheduler_options: {frequency: 0.2} }}
     let(:notifier_factory) { double('NotifierFactory') }


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

> In Ruby 3.0, positional arguments and keyword arguments will be separated.
> Ruby 2.7 will warn for behaviors that will change in Ruby 3.0.